### PR TITLE
Hibernating storage clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 ![Redkey Operator icon](docs/images/redkey-logo-512.png)
 
-Seamless Redkey Cluster Management on Kubernetes
+Seamless Redkey management on Kubernetes — in cluster or standalone mode
 
 [![GitHub License](https://img.shields.io/github/license/InditexTech/redkeyoperator)](LICENSE)
 [![GitHub Release](https://img.shields.io/github/v/release/InditexTech/redkeyoperator)](https://github.com/InditexTech/redkeyoperator/releases)
@@ -31,19 +31,20 @@ Seamless Redkey Cluster Management on Kubernetes
 
 ## Overview
 
-A **Redkey Cluster** is a key/value cluster built from either the [Redis official image](https://hub.docker.com/_/redis) or the [Valkey official image](https://hub.docker.com/r/valkey/valkey/). All nodes in the same cluster must use the same image family.
+A **Redkey** is a key/value store built from either the [Redis official image](https://hub.docker.com/_/redis) or the [Valkey official image](https://hub.docker.com/r/valkey/valkey/). A Redkey can run in **cluster** mode — a sharded Redis Cluster of one or more primaries, each with an optional set of replicas — or in **standalone** mode — a single, non-clustered instance. All nodes of the same Redkey use the same image family.
 
-**Redkey Operator** deploys and manages Redkey clusters on Kubernetes by implementing the [operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
+**Redkey Operator** deploys and manages Redkeys on Kubernetes by implementing the [operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
 
-It extends the Kubernetes API with a controller that reconciles the desired state declared in the `Redkey` resource, manages the Kubernetes objects required by the cluster, coordinates Redis-side operations through Redkey Robin, and keeps the cluster healthy during lifecycle changes.
+It extends the Kubernetes API with a controller that reconciles the desired state declared in the `Redkey` resource, manages the Kubernetes objects the Redkey requires, coordinates Redis-side operations through Redkey Robin, and keeps it healthy during lifecycle changes.
 
 Redkey Operator is built using [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) and [operator-sdk](https://github.com/operator-framework/operator-sdk).
 
 ## Key Features
 
-- Deploy Redkey clusters from a single `Redkey` custom resource using Redis or Valkey images
-- Configure topology with a selectable number of primaries and replicas per primary
-- Run ephemeral or persistent clusters with configurable storage size, storage class, access modes, and PVC cleanup behavior
+- Deploy Redkeys from a single `Redkey` custom resource using Redis or Valkey images
+- Choose the deployment mode: **cluster** (a sharded Redis Cluster) or **standalone** (a single, non-clustered instance)
+- Configure the cluster-mode topology with a selectable number of primaries and replicas per primary
+- Run ephemeral or persistent Redkeys with configurable storage size, storage class, access modes, and PVC cleanup behavior
 - Scale clusters up and down while reassigning slots and preserving cluster balance
 - Choose between fast operations and key-preserving rebalance flows through `purgeKeysOnRebalance`
 - Roll out changes to node image, Redis configuration, and pod resources

--- a/api/v1beta1/redkey_types.go
+++ b/api/v1beta1/redkey_types.go
@@ -184,6 +184,32 @@ type RedkeyStatus struct {
 
 	// ObservedGeneration is the most recent generation observed.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// LastAppliedPrimaries records the number of primaries of the last successfully applied,
+	// non-zero topology of a storage (non-ephemeral) cluster.
+	//
+	// WARNING — race-free scale-from-zero guard. This field is CONTINUOUSLY updated by the operator
+	// on every successful reconcile while the cluster is applied with primaries>0, and is NEVER
+	// cleared. It is intentionally maintained during steady state (NOT only at scale-to-zero) so the
+	// value is always persisted BEFORE any scale-to-zero. The root-level CEL validation rule on
+	// Redkey uses it to force a scale-up from zero back to the exact previous topology, preventing
+	// inconsistent PVC/node/slot remounts. Do NOT change this to record-on-scale-down-only and do NOT
+	// add clearing logic: either would reintroduce the admission-vs-reconcile race, because CEL runs
+	// synchronously at admission while the operator writes status asynchronously afterwards.
+	// Ephemeral clusters never set this field (they lose data on scale-to-zero, so no lock is needed).
+	//
+	// The Maximum bound keeps the CEL messageExpression that references this field within the API
+	// server's cost budget (it lets the cost estimator bound the size of string(...) conversions).
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=100000
+	LastAppliedPrimaries int32 `json:"lastAppliedPrimaries,omitempty"`
+
+	// LastAppliedReplicasPerPrimary records the replicasPerPrimary of the last successfully applied,
+	// non-zero topology of a storage (non-ephemeral) cluster. See LastAppliedPrimaries for the
+	// continuous-tracking / race-free rationale — the same WARNING applies here.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=100000
+	LastAppliedReplicasPerPrimary int32 `json:"lastAppliedReplicasPerPrimary,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -202,6 +228,24 @@ type RedkeyStatus struct {
 // +kubebuilder:printcolumn:name="Status",type="string",priority=1,JSONPath=".status.status",description="The cluster status"
 // +kubebuilder:printcolumn:name="Substatus",type="string",priority=1,JSONPath=".status.substatus.status",description="The cluster substatus"
 // +kubebuilder:printcolumn:name="Partition",type="string",priority=1,JSONPath=".status.substatus.upgradingPartition",description="Upgrading partition"
+//
+// Scale-from-zero topology lock (storage/non-ephemeral clusters only). These are ROOT-level rules
+// (placed on the Redkey type, not RedkeySpec) because only root-level rules can read self.status.
+// They rely on status.lastAppliedPrimaries / status.lastAppliedReplicasPerPrimary, which the
+// operator maintains CONTINUOUSLY while the cluster runs at primaries>0 (see RedkeyStatus fields).
+// That continuous tracking is what makes this check RACE-FREE: the previous topology is already
+// persisted before any scale-to-zero. Free scaling while primaries>0 stays unrestricted; only
+// scaling UP from zero is forced back to the exact previous topology. Ephemeral clusters and
+// fresh clusters created at zero (which never recorded a topology) are unaffected.
+//
+// NOTE: no messageExpression is used here. This CRD schema is very large (it embeds full
+// StatefulSet/PodSpec overrides), and a root-level messageExpression that reads self.status is
+// estimated by the API server's CEL cost budget against that whole schema, which exceeds the
+// (stricter) messageExpression budget by >100x even for a trivial expression. The static message
+// therefore points users to the exact required numbers in .status.lastAppliedPrimaries /
+// .status.lastAppliedReplicasPerPrimary instead of interpolating them.
+// +kubebuilder:validation:XValidation:rule="self.spec.ephemeral || oldSelf.spec.primaries != 0 || self.spec.primaries == 0 || !has(self.status.lastAppliedPrimaries) || self.spec.primaries == self.status.lastAppliedPrimaries",message="For storage clusters, scaling up from zero must restore the same primaries the cluster had before scaling to zero (see .status.lastAppliedPrimaries)"
+// +kubebuilder:validation:XValidation:rule="self.spec.ephemeral || oldSelf.spec.primaries != 0 || self.spec.primaries == 0 || !has(self.status.lastAppliedPrimaries) || self.spec.replicasPerPrimary == (has(self.status.lastAppliedReplicasPerPrimary) ? self.status.lastAppliedReplicasPerPrimary : 0)",message="For storage clusters, scaling up from zero must restore the same replicasPerPrimary the cluster had before scaling to zero (see .status.lastAppliedReplicasPerPrimary)"
 
 // Redkey is the Schema for the redkeys API.
 type Redkey struct {

--- a/charts/redkey-operator/crds/redkeys-crd.yaml
+++ b/charts/redkey-operator/crds/redkeys-crd.yaml
@@ -16562,6 +16562,23 @@ spec:
                   - type
                   type: object
                 type: array
+              lastAppliedPrimaries:
+                description: |-
+                  LastAppliedPrimaries records the primaries of the last applied non-zero topology
+                  of a storage (non-ephemeral) cluster. Continuously maintained and never cleared;
+                  used by the root-level scale-from-zero CEL rule (race-free). Do not change.
+                format: int32
+                maximum: 100000
+                minimum: 0
+                type: integer
+              lastAppliedReplicasPerPrimary:
+                description: |-
+                  LastAppliedReplicasPerPrimary records the replicasPerPrimary of the last applied
+                  non-zero topology of a storage (non-ephemeral) cluster. See LastAppliedPrimaries.
+                format: int32
+                maximum: 100000
+                minimum: 0
+                type: integer
               lastUpdatedAt:
                 description: LastUpdatedAt is the last time the status was updated.
                 format: date-time
@@ -16615,6 +16632,18 @@ spec:
             - phase
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: For storage clusters, scaling up from zero must restore the same
+            primaries the cluster had before scaling to zero (see .status.lastAppliedPrimaries)
+          rule: self.spec.ephemeral || oldSelf.spec.primaries != 0 || self.spec.primaries
+            == 0 || !has(self.status.lastAppliedPrimaries) || self.spec.primaries
+            == self.status.lastAppliedPrimaries
+        - message: For storage clusters, scaling up from zero must restore the same
+            replicasPerPrimary the cluster had before scaling to zero (see .status.lastAppliedReplicasPerPrimary)
+          rule: 'self.spec.ephemeral || oldSelf.spec.primaries != 0 || self.spec.primaries
+            == 0 || !has(self.status.lastAppliedPrimaries) || self.spec.replicasPerPrimary
+            == (has(self.status.lastAppliedReplicasPerPrimary) ? self.status.lastAppliedReplicasPerPrimary
+            : 0)'
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/redkey.inditex.dev_redkeys.yaml
+++ b/config/crd/bases/redkey.inditex.dev_redkeys.yaml
@@ -17320,6 +17320,36 @@ spec:
                   - type
                   type: object
                 type: array
+              lastAppliedPrimaries:
+                description: |-
+                  LastAppliedPrimaries records the number of primaries of the last successfully applied,
+                  non-zero topology of a storage (non-ephemeral) cluster.
+
+                  WARNING — race-free scale-from-zero guard. This field is CONTINUOUSLY updated by the operator
+                  on every successful reconcile while the cluster is applied with primaries>0, and is NEVER
+                  cleared. It is intentionally maintained during steady state (NOT only at scale-to-zero) so the
+                  value is always persisted BEFORE any scale-to-zero. The root-level CEL validation rule on
+                  Redkey uses it to force a scale-up from zero back to the exact previous topology, preventing
+                  inconsistent PVC/node/slot remounts. Do NOT change this to record-on-scale-down-only and do NOT
+                  add clearing logic: either would reintroduce the admission-vs-reconcile race, because CEL runs
+                  synchronously at admission while the operator writes status asynchronously afterwards.
+                  Ephemeral clusters never set this field (they lose data on scale-to-zero, so no lock is needed).
+
+                  The Maximum bound keeps the CEL messageExpression that references this field within the API
+                  server's cost budget (it lets the cost estimator bound the size of string(...) conversions).
+                format: int32
+                maximum: 100000
+                minimum: 0
+                type: integer
+              lastAppliedReplicasPerPrimary:
+                description: |-
+                  LastAppliedReplicasPerPrimary records the replicasPerPrimary of the last successfully applied,
+                  non-zero topology of a storage (non-ephemeral) cluster. See LastAppliedPrimaries for the
+                  continuous-tracking / race-free rationale — the same WARNING applies here.
+                format: int32
+                maximum: 100000
+                minimum: 0
+                type: integer
               lastUpdatedAt:
                 description: LastUpdatedAt is the last time the status was updated.
                 format: date-time
@@ -17373,6 +17403,18 @@ spec:
             - phase
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: For storage clusters, scaling up from zero must restore the same
+            primaries the cluster had before scaling to zero (see .status.lastAppliedPrimaries)
+          rule: self.spec.ephemeral || oldSelf.spec.primaries != 0 || self.spec.primaries
+            == 0 || !has(self.status.lastAppliedPrimaries) || self.spec.primaries
+            == self.status.lastAppliedPrimaries
+        - message: For storage clusters, scaling up from zero must restore the same
+            replicasPerPrimary the cluster had before scaling to zero (see .status.lastAppliedReplicasPerPrimary)
+          rule: 'self.spec.ephemeral || oldSelf.spec.primaries != 0 || self.spec.primaries
+            == 0 || !has(self.status.lastAppliedPrimaries) || self.spec.replicasPerPrimary
+            == (has(self.status.lastAppliedReplicasPerPrimary) ? self.status.lastAppliedReplicasPerPrimary
+            : 0)'
     served: true
     storage: true
     subresources:

--- a/docs/operator-guide/scaling.md
+++ b/docs/operator-guide/scaling.md
@@ -210,7 +210,37 @@ or as a building block for external autoscalers.
 | :--- | :--- |
 | **Create with `spec.primaries: 0`** | No-op: the operator creates **nothing** — no Robin, no RBAC, no StatefulSet, no configs. Status is set to `Ready` with `replicas: 0`. |
 | **Scale from >0 to 0** | The operator creates a `RedkeyConfig` with `primaries: 0`. Robin deletes the StatefulSet, Service, ConfigMap, and PDB. If `spec.deletePVC: true`, PVCs are also deleted. Once Robin marks the config as Applied, the operator cleans up Robin's Deployment, RBAC, and all configs. |
-| **Scale from 0 to >0** | Normal creation path: the operator creates RBAC, Robin Deployment, and a new config. Robin creates all cluster objects from scratch. |
+| **Scale from 0 to >0** | Normal creation path: the operator creates RBAC, Robin Deployment, and a new config. Robin creates all cluster objects from scratch. **For storage (non-ephemeral) clusters** the target topology is constrained — see [Scale-up-from-zero topology lock](#scale-up-from-zero-topology-lock-storage-clusters). |
+
+### Scale-up-from-zero topology lock (storage clusters)
+
+For **storage (non-ephemeral) clusters**, scaling **up from zero** is only allowed back to the
+**exact same topology** the cluster last ran with — the same `spec.primaries` **and**
+`spec.replicasPerPrimary`. This is enforced by a CEL validation rule on the `Redkey` CRD and
+rejects the change at admission time (e.g. `kubectl apply`/`kubectl scale`).
+
+**Why:** persistent volumes keep the Redis node/slot metadata of the topology that created them.
+Coming back from zero with a *different* number of primaries (or replicas) would remount those PVCs
+into a mismatched layout and produce an inconsistent cluster. Locking the scale-up to the previous
+topology prevents that.
+
+What is and isn't restricted:
+
+- ✅ **Free scaling while `primaries > 0`** is unrestricted — scale up/down to any valid topology.
+- ✅ **Ephemeral clusters** are never restricted (they hold no persistent data, so a fresh layout is fine).
+- ✅ **Fresh clusters created at `primaries: 0`** (that never ran) can scale up to any topology.
+- ❌ A storage cluster that ran at, say, `3` primaries / `1` replica, was scaled to `0`, and is then
+  scaled up to a different topology (e.g. `2` primaries, or `3` primaries / `2` replicas) is **rejected**.
+  The exact topology to return to is published in `.status.lastAppliedPrimaries` and
+  `.status.lastAppliedReplicasPerPrimary`, and the rejection message points to those fields.
+
+> **Race-free by design — do not change.** The rule reads `status.lastAppliedPrimaries` /
+> `status.lastAppliedReplicasPerPrimary`, which the operator updates **continuously** on every
+> successful reconcile while the cluster runs at `primaries > 0` (never only at scale-to-zero, and
+> never cleared). Recording it continuously guarantees the value is already persisted **before** any
+> scale-to-zero, which is what makes the check free of the admission-vs-reconcile race. Changing this
+> to record-only-at-scale-down, or adding clearing logic, would reintroduce that race and allow
+> inconsistent PVC remounts.
 
 ### Example
 
@@ -236,15 +266,20 @@ kubectl scale redkey my-cluster --replicas=0
 kubectl scale redkey my-cluster --replicas=3
 ```
 
+> **Storage clusters:** the scale-back-up target must match the topology the cluster had before
+> scaling to zero (see [Scale-up-from-zero topology lock](#scale-up-from-zero-topology-lock-storage-clusters)).
+> A mismatched `--replicas` value is rejected by the API server.
+
 ### PVC handling
 
 When scaling to zero with persistent storage:
 
 - **`spec.deletePVC: true`** (default): Robin deletes all PersistentVolumeClaims. Data is
   lost and a fresh cluster is created when scaling back up.
-- **`spec.deletePVC: false`**: PVCs are preserved. However, the Redis cluster topology
-  metadata inside the volumes becomes stale — scaling back up creates a fresh cluster
-  regardless.
+- **`spec.deletePVC: false`**: PVCs are preserved. Because the volumes keep the previous cluster's
+  node/slot metadata, scaling back up is **locked to the same topology** (same primaries and
+  replicas) via the [scale-up-from-zero topology lock](#scale-up-from-zero-topology-lock-storage-clusters),
+  which avoids remounting the volumes into an inconsistent layout.
 
 ### Status after scale to zero
 

--- a/docs/operator-guide/scaling.md
+++ b/docs/operator-guide/scaling.md
@@ -204,6 +204,19 @@ infrastructure from the namespace while preserving the `Redkey` resource itself.
 This is useful for development/staging environments, cost savings during off-peak hours,
 or as a building block for external autoscalers.
 
+### Hibernation (storage clusters)
+
+For **storage (non-ephemeral) clusters with `spec.deletePVC: false`**, scaling to zero is a
+**hibernation**: the compute (Redis pods, Robin, StatefulSet, Service, PDB, ConfigMap, RBAC) is
+torn down to free resources, but the **data is preserved** in the PersistentVolumeClaims. The
+cluster is later **woken up** (resumed) by scaling back up to the **same topology** it had before
+hibernating, which remounts the existing volumes and restores the cluster from its persisted
+state. To keep the restore consistent, waking up is locked to that previous topology — see
+[Scale-up-from-zero topology lock](#scale-up-from-zero-topology-lock-storage-clusters).
+
+By contrast, scaling an **ephemeral** cluster (or a storage cluster with `deletePVC: true`) to zero
+is a plain teardown, not hibernation: no data survives and scaling back up creates a fresh cluster.
+
 ### Behaviour
 
 | Scenario | Effect |
@@ -214,10 +227,10 @@ or as a building block for external autoscalers.
 
 ### Scale-up-from-zero topology lock (storage clusters)
 
-For **storage (non-ephemeral) clusters**, scaling **up from zero** is only allowed back to the
-**exact same topology** the cluster last ran with — the same `spec.primaries` **and**
-`spec.replicasPerPrimary`. This is enforced by a CEL validation rule on the `Redkey` CRD and
-rejects the change at admission time (e.g. `kubectl apply`/`kubectl scale`).
+For **storage (non-ephemeral) clusters**, scaling **up from zero** — i.e. **waking a hibernated
+cluster** — is only allowed back to the **exact same topology** the cluster last ran with: the same
+`spec.primaries` **and** `spec.replicasPerPrimary`. This is enforced by a CEL validation rule on the
+`Redkey` CRD and rejects the change at admission time (e.g. `kubectl apply`/`kubectl scale`).
 
 **Why:** persistent volumes keep the Redis node/slot metadata of the topology that created them.
 Coming back from zero with a *different* number of primaries (or replicas) would remount those PVCs
@@ -274,12 +287,13 @@ kubectl scale redkey my-cluster --replicas=3
 
 When scaling to zero with persistent storage:
 
-- **`spec.deletePVC: true`** (default): Robin deletes all PersistentVolumeClaims. Data is
-  lost and a fresh cluster is created when scaling back up.
-- **`spec.deletePVC: false`**: PVCs are preserved. Because the volumes keep the previous cluster's
-  node/slot metadata, scaling back up is **locked to the same topology** (same primaries and
-  replicas) via the [scale-up-from-zero topology lock](#scale-up-from-zero-topology-lock-storage-clusters),
-  which avoids remounting the volumes into an inconsistent layout.
+- **`spec.deletePVC: false`** (default): PVCs are preserved — this is **hibernation**. Because the
+  volumes keep the previous cluster's node/slot metadata, waking up (scaling back up) is **locked to
+  the same topology** (same primaries and replicas) via the
+  [scale-up-from-zero topology lock](#scale-up-from-zero-topology-lock-storage-clusters), which
+  avoids remounting the volumes into an inconsistent layout.
+- **`spec.deletePVC: true`**: Robin deletes all PersistentVolumeClaims. This is a teardown, not
+  hibernation: data is lost and a fresh cluster is created when scaling back up.
 
 ### Status after scale to zero
 

--- a/docs/redkey-cluster-status.md
+++ b/docs/redkey-cluster-status.md
@@ -328,6 +328,30 @@ redis-cluster-ephemeral   cluster   0           0          true        true     
 redis-cluster-ephemeral   cluster   0           0          true        true                  false       Ready         Ready
 ```
 
+#### Scale-up-from-zero topology lock (storage clusters)
+
+For **storage (non-ephemeral)** clusters, scaling **up from zero** is locked to the exact topology
+the cluster last ran with (same `spec.primaries` and `spec.replicasPerPrimary`). This prevents
+remounting persistent volumes \u2014 which retain Redis node/slot metadata \u2014 into a mismatched layout.
+The constraint is enforced by a CEL rule on the `Redkey` CRD and is rejected at admission time.
+Free scaling while `primaries > 0`, ephemeral clusters, and fresh clusters created at `0` are not
+restricted. See [Scaling \u2192 Scale-up-from-zero topology lock](operator-guide/scaling.md#scale-up-from-zero-topology-lock-storage-clusters).
+
+The operator supports this by continuously tracking the last applied non-zero topology in two
+status fields:
+
+| Field | Meaning |
+| :--- | :--- |
+| `.status.lastAppliedPrimaries` | Primaries of the last applied non-zero topology (storage clusters only). |
+| `.status.lastAppliedReplicasPerPrimary` | Replicas-per-primary of the last applied non-zero topology (storage clusters only). |
+
+> **Race-free by design.** These fields are updated on **every** successful reconcile while the
+> cluster runs at `primaries > 0` (not only at scale-to-zero) and are **never cleared**, so the
+> previous topology is always persisted before any scale-to-zero. This is intentional \u2014 changing it
+> would reintroduce an admission-vs-reconcile race. Ephemeral clusters never populate these fields.
+
+
+
 ### Redkey Cluster Upgrading (Fast upgrading)
 
 Two Substatus are defined:

--- a/docs/redkey-cluster-status.md
+++ b/docs/redkey-cluster-status.md
@@ -330,12 +330,15 @@ redis-cluster-ephemeral   cluster   0           0          true        true     
 
 #### Scale-up-from-zero topology lock (storage clusters)
 
-For **storage (non-ephemeral)** clusters, scaling **up from zero** is locked to the exact topology
-the cluster last ran with (same `spec.primaries` and `spec.replicasPerPrimary`). This prevents
-remounting persistent volumes \u2014 which retain Redis node/slot metadata \u2014 into a mismatched layout.
+For **storage (non-ephemeral)** clusters, scaling to zero with `deletePVC: false` is a
+**hibernation**: the compute is removed but the data is kept in the PVCs. **Waking up** (scaling
+back up from zero) is locked to the exact topology the cluster last ran with (same `spec.primaries`
+and `spec.replicasPerPrimary`). This prevents remounting persistent volumes — which retain Redis
+node/slot metadata — into a mismatched layout.
 The constraint is enforced by a CEL rule on the `Redkey` CRD and is rejected at admission time.
 Free scaling while `primaries > 0`, ephemeral clusters, and fresh clusters created at `0` are not
-restricted. See [Scaling \u2192 Scale-up-from-zero topology lock](operator-guide/scaling.md#scale-up-from-zero-topology-lock-storage-clusters).
+restricted. See [Scaling → Hibernation](operator-guide/scaling.md#hibernation-storage-clusters) and
+[Scaling → Scale-up-from-zero topology lock](operator-guide/scaling.md#scale-up-from-zero-topology-lock-storage-clusters).
 
 The operator supports this by continuously tracking the last applied non-zero topology in two
 status fields:

--- a/internal/controller/redkey_config.go
+++ b/internal/controller/redkey_config.go
@@ -165,6 +165,22 @@ func (r *RedkeyReconciler) aggregateStatus(ctx context.Context, cluster *redisv1
 		latest.Status.LastUpdatedAt = &now
 		latest.Status.ObservedGeneration = observedGeneration
 
+		// Continuously track the last applied, non-zero topology for storage (non-ephemeral)
+		// clusters. This is deliberately updated on EVERY successful reconcile while the cluster is
+		// Applied at primaries>0 — NOT only at scale-to-zero — and is NEVER cleared. Recording it here,
+		// during steady state, guarantees the value is already persisted BEFORE any scale-to-zero,
+		// which is exactly what makes the root-level "scale-up-from-zero must match the previous
+		// topology" CEL rule RACE-FREE. Do NOT move this to a scale-down-only path and do NOT add
+		// clearing logic: either would reintroduce the admission-vs-reconcile race and allow
+		// inconsistent PVC remounts. Only Applied configs are used so in-progress scale targets are
+		// not captured until they have actually converged.
+		if !latest.Spec.Ephemeral &&
+			activeConfig.Status.ConfigPhase == redisv1.ConfigPhaseApplied &&
+			activeConfig.Spec.Primaries > 0 {
+			latest.Status.LastAppliedPrimaries = activeConfig.Spec.Primaries
+			latest.Status.LastAppliedReplicasPerPrimary = activeConfig.Spec.ReplicasPerPrimary
+		}
+
 		lastStatus, lastPhase = latest.Status.Status, latest.Status.Phase
 		if err := r.Status().Update(ctx, &latest); err != nil {
 			return err

--- a/test/e2e/scale_from_zero_lock_test.go
+++ b/test/e2e/scale_from_zero_lock_test.go
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: 2026 INDUSTRIA DE DISEÑO TEXTIL, S.A. (INDITEX, S.A.)
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	redkeyv1beta1 "github.com/inditextech/redkeyoperator/api/v1beta1"
+	"github.com/inditextech/redkeyoperator/test/e2e/framework"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// expectScaleUpRejected attempts to change the topology and asserts the API server rejects it
+// (the scale-up-from-zero CEL rule), and that the rejection message names the expected topology.
+func expectScaleUpRejected(
+	ctx context.Context, key types.NamespacedName, mutate func(*redkeyv1beta1.Redkey), msgSubstrings ...string,
+) {
+	cluster := &redkeyv1beta1.Redkey{}
+	Expect(k8sClient.Get(ctx, key, cluster)).To(Succeed())
+	mutate(cluster)
+	err := k8sClient.Update(ctx, cluster)
+	Expect(err).To(HaveOccurred(), "scale-up from zero to a mismatched topology must be rejected")
+	for _, s := range msgSubstrings {
+		Expect(err.Error()).To(ContainSubstring(s))
+	}
+}
+
+// waitForLastAppliedPrimaries polls until the operator has recorded the given last-applied topology
+// in the Redkey status (continuous tracking of storage clusters running at primaries>0).
+func waitForLastAppliedPrimaries(ctx context.Context, key types.NamespacedName, primaries, replicas int32) {
+	Eventually(func(g Gomega) {
+		cluster := &redkeyv1beta1.Redkey{}
+		g.Expect(k8sClient.Get(ctx, key, cluster)).To(Succeed())
+		g.Expect(cluster.Status.LastAppliedPrimaries).To(Equal(primaries))
+		g.Expect(cluster.Status.LastAppliedReplicasPerPrimary).To(Equal(replicas))
+	}, framework.HealthTimeout, framework.DefaultPollInterval).Should(Succeed())
+}
+
+var _ = Describe("Scale-up-from-zero topology lock", Ordered, Label("scale-to-zero"), func() {
+	var (
+		suiteCtx  context.Context
+		ctx       context.Context
+		ns        *corev1.Namespace
+		clusterNs string
+	)
+
+	framework.SetupSpecContexts(&suiteCtx, &ctx, 20*time.Minute)
+
+	BeforeAll(func() {
+		By("creating a test namespace")
+		var err error
+		ns, err = framework.CreateNamespace(suiteCtx, k8sClient, "e2e-scale-zero-lock")
+		Expect(err).NotTo(HaveOccurred())
+		clusterNs = ns.Name
+		_, _ = fmt.Fprintf(GinkgoWriter, "Using namespace: %s\n", clusterNs)
+	})
+
+	AfterAll(func() {
+		By("cleaning up the test namespace")
+		if ns != nil {
+			_ = framework.DeleteNamespace(suiteCtx, k8sClient, ns)
+		}
+	})
+
+	AfterEach(func() {
+		framework.CollectDebugInfoOnFailure(k8sClient, clusterNs)
+	})
+
+	// --- Storage cluster without replicas: lock on primaries ---
+
+	Context("Storage cluster (3 primaries) scaled to zero and back", func() {
+		const clusterName = "lock-storage-3"
+		key := func() types.NamespacedName {
+			return types.NamespacedName{Name: clusterName, Namespace: clusterNs}
+		}
+
+		AfterAll(func() {
+			_ = framework.DeleteRedkey(ctx, k8sClient, clusterName, clusterNs)
+		})
+
+		It("creates a 3-primary storage cluster and records the applied topology", func() {
+			opts := framework.DefaultClusterOptions(clusterName, clusterNs).WithPVC("100Mi")
+			opts.Primaries = 3
+			cluster := opts.BuildRedkey()
+			cluster.Spec.DeletePVC = new(false)
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+			waitForScaledCluster(ctx, clusterName, clusterNs, 3)
+			waitForLastAppliedPrimaries(ctx, key(), 3, 0)
+		})
+
+		It("scales down to 0 primaries", func() {
+			updateClusterTopology(ctx, key(), func(c *redkeyv1beta1.Redkey) {
+				c.Spec.Primaries = 0
+			})
+			waitForScaledToZero(ctx, clusterName, clusterNs)
+		})
+
+		It("rejects scaling up from zero to fewer primaries", func() {
+			expectScaleUpRejected(ctx, key(), func(c *redkeyv1beta1.Redkey) {
+				c.Spec.Primaries = 2
+			}, "restore the same primaries")
+		})
+
+		It("rejects scaling up from zero to more primaries", func() {
+			expectScaleUpRejected(ctx, key(), func(c *redkeyv1beta1.Redkey) {
+				c.Spec.Primaries = 5
+			}, "restore the same primaries")
+		})
+
+		It("does not mention replicas in the rejection message when there are none", func() {
+			cluster := &redkeyv1beta1.Redkey{}
+			Expect(k8sClient.Get(ctx, key(), cluster)).To(Succeed())
+			cluster.Spec.Primaries = 4
+			err := k8sClient.Update(ctx, cluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(".status.lastAppliedPrimaries"))
+			Expect(err.Error()).NotTo(ContainSubstring("replicasPerPrimary"))
+		})
+
+		It("accepts scaling up from zero back to the exact previous topology", func() {
+			updateClusterTopology(ctx, key(), func(c *redkeyv1beta1.Redkey) {
+				c.Spec.Primaries = 3
+			})
+			waitForScaledCluster(ctx, clusterName, clusterNs, 3)
+		})
+	})
+
+	// --- Storage cluster with replicas: lock on primaries AND replicas ---
+
+	Context("Storage cluster (3 primaries / 1 replica) scaled to zero and back", func() {
+		const clusterName = "lock-storage-3-1"
+		key := func() types.NamespacedName {
+			return types.NamespacedName{Name: clusterName, Namespace: clusterNs}
+		}
+
+		AfterAll(func() {
+			_ = framework.DeleteRedkey(ctx, k8sClient, clusterName, clusterNs)
+		})
+
+		It("creates a 3-primary/1-replica storage cluster and records the applied topology", func() {
+			opts := framework.DefaultClusterOptions(clusterName, clusterNs).WithPVC("100Mi").WithReplicas(1)
+			opts.Primaries = 3
+			cluster := opts.BuildRedkey()
+			cluster.Spec.DeletePVC = new(false)
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+			// 3 primaries + 3 replicas = 6 nodes
+			waitForScaledCluster(ctx, clusterName, clusterNs, 6)
+			waitForLastAppliedPrimaries(ctx, key(), 3, 1)
+		})
+
+		It("scales down to 0 primaries", func() {
+			updateClusterTopology(ctx, key(), func(c *redkeyv1beta1.Redkey) {
+				c.Spec.Primaries = 0
+			})
+			waitForScaledToZero(ctx, clusterName, clusterNs)
+		})
+
+		It("rejects scaling up from zero with a different replica count", func() {
+			expectScaleUpRejected(ctx, key(), func(c *redkeyv1beta1.Redkey) {
+				c.Spec.Primaries = 3
+				c.Spec.ReplicasPerPrimary = 2
+			}, "restore the same replicasPerPrimary")
+		})
+
+		It("accepts scaling up from zero back to the exact previous primaries and replicas", func() {
+			updateClusterTopology(ctx, key(), func(c *redkeyv1beta1.Redkey) {
+				c.Spec.Primaries = 3
+				c.Spec.ReplicasPerPrimary = 1
+			})
+			waitForScaledCluster(ctx, clusterName, clusterNs, 6)
+		})
+	})
+
+	// --- Ephemeral clusters are never locked ---
+
+	Context("Ephemeral cluster scaled to zero and back to a different topology", func() {
+		const clusterName = "lock-ephemeral-free"
+		key := func() types.NamespacedName {
+			return types.NamespacedName{Name: clusterName, Namespace: clusterNs}
+		}
+
+		AfterAll(func() {
+			_ = framework.DeleteRedkey(ctx, k8sClient, clusterName, clusterNs)
+		})
+
+		It("creates a 3-primary ephemeral cluster", func() {
+			opts := framework.DefaultClusterOptions(clusterName, clusterNs)
+			opts.Primaries = 3
+			_, err := framework.CreateRedkey(ctx, k8sClient, opts)
+			Expect(err).NotTo(HaveOccurred())
+			waitForScaledCluster(ctx, clusterName, clusterNs, 3)
+		})
+
+		It("does not record any last-applied topology for ephemeral clusters", func() {
+			cluster := &redkeyv1beta1.Redkey{}
+			Expect(k8sClient.Get(ctx, key(), cluster)).To(Succeed())
+			Expect(cluster.Status.LastAppliedPrimaries).To(Equal(int32(0)))
+		})
+
+		It("scales down to 0 primaries", func() {
+			updateClusterTopology(ctx, key(), func(c *redkeyv1beta1.Redkey) {
+				c.Spec.Primaries = 0
+			})
+			waitForScaledToZero(ctx, clusterName, clusterNs)
+		})
+
+		It("allows scaling up from zero to a different topology (no lock)", func() {
+			updateClusterTopology(ctx, key(), func(c *redkeyv1beta1.Redkey) {
+				c.Spec.Primaries = 5
+			})
+			waitForScaledCluster(ctx, clusterName, clusterNs, 5)
+		})
+	})
+})

--- a/test/e2e/scaling_test.go
+++ b/test/e2e/scaling_test.go
@@ -823,5 +823,3 @@ var _ = Describe("Cluster Scaling", Ordered, Label("scaling"), func() {
 		})
 	})
 })
-
-

--- a/test/e2e/scaling_test.go
+++ b/test/e2e/scaling_test.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // updateClusterTopology mutates a Redkey's spec with conflict-retry, used to
@@ -699,4 +700,128 @@ var _ = Describe("Cluster Scaling", Ordered, Label("scaling"), func() {
 			Expect(size).To(Equal(0), "fast scaling recreates the cluster and purges all data")
 		})
 	})
+
+	// --- deletePVC: removed ordinals' PVCs are deleted on scale-down (deletePVC=true). ---
+	// The StatefulSet PVC retention policy is set to WhenScaled=Delete for deletePVC=true, so the
+	// volumes of the ordinals removed by a scale-down are cleaned up instead of lingering with
+	// stale slot/node data.
+
+	Context("Persistent cluster with deletePVC=true (scale-down deletes removed PVCs)", func() {
+		const clusterName = "scale-deletepvc"
+		key := func() types.NamespacedName {
+			return types.NamespacedName{Name: clusterName, Namespace: clusterNs}
+		}
+
+		listDataPVCNames := func() []string {
+			pvcs := &corev1.PersistentVolumeClaimList{}
+			Expect(k8sClient.List(ctx, pvcs,
+				client.InNamespace(clusterNs),
+				client.MatchingLabels(framework.RedisPodLabels(clusterName)),
+			)).To(Succeed())
+			names := make([]string, 0, len(pvcs.Items))
+			for i := range pvcs.Items {
+				names = append(names, pvcs.Items[i].Name)
+			}
+			return names
+		}
+
+		AfterAll(func() {
+			_ = framework.DeleteRedkey(ctx, k8sClient, clusterName, clusterNs)
+		})
+
+		It("creates a 3-primary persistent cluster with deletePVC=true", func() {
+			opts := framework.DefaultClusterOptions(clusterName, clusterNs).WithPVC("100Mi")
+			opts.Primaries = 3
+			opts.ReplicasPerPrimary = 0
+			cluster := opts.BuildRedkey()
+			cluster.Spec.DeletePVC = new(true)
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+			waitForScaledCluster(ctx, clusterName, clusterNs, 3)
+
+			By("verifying one PVC exists per primary ordinal")
+			Expect(listDataPVCNames()).To(ConsistOf(
+				"data-"+clusterName+"-0",
+				"data-"+clusterName+"-1",
+				"data-"+clusterName+"-2",
+			))
+		})
+
+		It("deletes the removed ordinals' PVCs when scaling down 3→1", func() {
+			updateClusterTopology(ctx, key(), func(c *redkeyv1beta1.Redkey) {
+				c.Spec.Primaries = 1
+			})
+
+			waitForScaledCluster(ctx, clusterName, clusterNs, 1)
+
+			By("verifying only the surviving ordinal's PVC remains (removed PVCs deleted)")
+			Eventually(listDataPVCNames, framework.HealthTimeout, framework.DefaultPollInterval).
+				Should(ConsistOf("data-" + clusterName + "-0"))
+		})
+	})
+
+	// --- deletePVC=false counterpart: removed ordinals' PVCs are retained on scale-down. ---
+	// With deletePVC=false the StatefulSet PVC retention policy is WhenScaled=Retain, so the
+	// volumes of the ordinals removed by a scale-down are preserved (data is kept).
+
+	Context("Persistent cluster with deletePVC=false (scale-down retains removed PVCs)", func() {
+		const clusterName = "scale-keeppvc"
+		key := func() types.NamespacedName {
+			return types.NamespacedName{Name: clusterName, Namespace: clusterNs}
+		}
+
+		listDataPVCNames := func() []string {
+			pvcs := &corev1.PersistentVolumeClaimList{}
+			Expect(k8sClient.List(ctx, pvcs,
+				client.InNamespace(clusterNs),
+				client.MatchingLabels(framework.RedisPodLabels(clusterName)),
+			)).To(Succeed())
+			names := make([]string, 0, len(pvcs.Items))
+			for i := range pvcs.Items {
+				names = append(names, pvcs.Items[i].Name)
+			}
+			return names
+		}
+
+		AfterAll(func() {
+			_ = framework.DeleteRedkey(ctx, k8sClient, clusterName, clusterNs)
+		})
+
+		It("creates a 3-primary persistent cluster with deletePVC=false", func() {
+			opts := framework.DefaultClusterOptions(clusterName, clusterNs).WithPVC("100Mi")
+			opts.Primaries = 3
+			opts.ReplicasPerPrimary = 0
+			cluster := opts.BuildRedkey()
+			cluster.Spec.DeletePVC = new(false)
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+			waitForScaledCluster(ctx, clusterName, clusterNs, 3)
+
+			By("verifying one PVC exists per primary ordinal")
+			Expect(listDataPVCNames()).To(ConsistOf(
+				"data-"+clusterName+"-0",
+				"data-"+clusterName+"-1",
+				"data-"+clusterName+"-2",
+			))
+		})
+
+		It("retains the removed ordinals' PVCs when scaling down 3→1", func() {
+			updateClusterTopology(ctx, key(), func(c *redkeyv1beta1.Redkey) {
+				c.Spec.Primaries = 1
+			})
+
+			waitForScaledCluster(ctx, clusterName, clusterNs, 1)
+
+			By("verifying all three PVCs remain (removed ordinals' PVCs retained)")
+			// WhenScaled=Retain never deletes; poll briefly to prove no async deletion occurs.
+			Consistently(listDataPVCNames, 15*time.Second, framework.DefaultPollInterval).
+				Should(ConsistOf(
+					"data-"+clusterName+"-0",
+					"data-"+clusterName+"-1",
+					"data-"+clusterName+"-2",
+				))
+		})
+	})
 })
+
+

--- a/test/integration/scale_from_zero_lock_test.go
+++ b/test/integration/scale_from_zero_lock_test.go
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: 2026 INDUSTRIA DE DISEÑO TEXTIL, S.A. (INDITEX, S.A.)
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package integration_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	redisv1 "github.com/inditextech/redkeyoperator/api/v1beta1"
+)
+
+// These tests exercise the scale-up-from-zero topology lock for storage (non-ephemeral) clusters.
+//
+// The lock is a root-level CEL rule on the Redkey CRD (enforced by the envtest API server) that
+// forces a scale-up from zero back to the exact previous topology (primaries + replicasPerPrimary).
+// It reads status.lastAppliedPrimaries / status.lastAppliedReplicasPerPrimary, which the operator
+// maintains CONTINUOUSLY while the cluster runs at primaries>0 (never only at scale-to-zero, never
+// cleared). That continuous tracking is what makes the check RACE-FREE: the previous topology is
+// persisted BEFORE any scale-to-zero, so the guard holds immediately without needing a
+// post-scale-down reconcile. These tests assert both properties explicitly.
+var _ = Describe("Scale-up-from-zero topology lock (CEL)", func() {
+	const namespace = "default"
+	ctx := context.Background()
+
+	newStorageCluster := func(name string, primaries, replicas int32) *redisv1.Redkey {
+		purgeKeys := false
+		return &redisv1.Redkey{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: redisv1.RedkeySpec{
+				Primaries:            primaries,
+				ReplicasPerPrimary:   replicas,
+				Ephemeral:            false,
+				Storage:              "1Gi",
+				StorageClassName:     "standard",
+				AccessModes:          []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				PurgeKeysOnRebalance: &purgeKeys,
+				Robin:                redisv1.RobinSpec{Image: "redkey-robin:latest"},
+			},
+		}
+	}
+
+	// bringToAppliedReady creates the cluster, reconciles it, marks its highest-sequence config
+	// Applied+Ready, and reconciles again so the operator records the last applied topology.
+	bringToAppliedReady := func(cluster *redisv1.Redkey) redisv1.Redkey {
+		name := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+		reconcileCluster(ctx, name)
+
+		configs := listConfigs(ctx, cluster.Name, namespace)
+		Expect(configs).NotTo(BeEmpty())
+		last := &configs[len(configs)-1]
+		last.Status.ConfigPhase = redisv1.ConfigPhaseApplied
+		last.Status.Status = redisv1.ClusterStatusReady
+		updateConfigStatus(ctx, last)
+
+		reconcileCluster(ctx, name)
+
+		var updated redisv1.Redkey
+		Expect(k8sClient.Get(ctx, name, &updated)).To(Succeed())
+		return updated
+	}
+
+	// applyScaleTarget scales primaries (and replicas) via the highest applied config so the
+	// operator records the new applied topology, mimicking a completed free scale while >0.
+	updateSpec := func(name types.NamespacedName, mutate func(c *redisv1.Redkey)) error {
+		var c redisv1.Redkey
+		Expect(k8sClient.Get(ctx, name, &c)).To(Succeed())
+		mutate(&c)
+		return k8sClient.Update(ctx, &c)
+	}
+
+	Context("continuous tracking of the last applied topology", func() {
+		It("records lastAppliedPrimaries once the cluster is applied at >0", func() {
+			const name = "lock-track-record"
+			cl := bringToAppliedReady(newStorageCluster(name, 3, 0))
+			DeferCleanup(func() { deleteCluster(ctx, name, namespace) })
+
+			Expect(cl.Status.LastAppliedPrimaries).To(Equal(int32(3)))
+			Expect(cl.Status.LastAppliedReplicasPerPrimary).To(Equal(int32(0)))
+		})
+
+		It("updates lastAppliedPrimaries as the applied topology changes while >0", func() {
+			const name = "lock-track-update"
+			nn := types.NamespacedName{Name: name, Namespace: namespace}
+			bringToAppliedReady(newStorageCluster(name, 3, 0))
+			DeferCleanup(func() { deleteCluster(ctx, name, namespace) })
+
+			// Free scale up to 5 while >0: a new config is created; it is not yet Applied, so the
+			// recorded value must stay at 3 (we never capture an in-progress target).
+			Expect(updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 5 })).To(Succeed())
+			reconcileCluster(ctx, nn)
+
+			var midway redisv1.Redkey
+			Expect(k8sClient.Get(ctx, nn, &midway)).To(Succeed())
+			Expect(midway.Status.LastAppliedPrimaries).To(Equal(int32(3)),
+				"in-progress scale target must not be recorded until applied")
+
+			// Mark the new config Applied+Ready and reconcile: now the recorded value tracks to 5.
+			configs := listConfigs(ctx, name, namespace)
+			last := &configs[len(configs)-1]
+			last.Status.ConfigPhase = redisv1.ConfigPhaseApplied
+			last.Status.Status = redisv1.ClusterStatusReady
+			updateConfigStatus(ctx, last)
+			reconcileCluster(ctx, nn)
+
+			var after redisv1.Redkey
+			Expect(k8sClient.Get(ctx, nn, &after)).To(Succeed())
+			Expect(after.Status.LastAppliedPrimaries).To(Equal(int32(5)))
+		})
+
+		It("does not track topology for ephemeral clusters", func() {
+			const name = "lock-track-ephemeral"
+			cluster := newTestCluster(name, namespace) // ephemeral, 3 primaries
+			nn := types.NamespacedName{Name: name, Namespace: namespace}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			DeferCleanup(func() { deleteCluster(ctx, name, namespace) })
+			reconcileCluster(ctx, nn)
+
+			configs := listConfigs(ctx, name, namespace)
+			configs[0].Status.ConfigPhase = redisv1.ConfigPhaseApplied
+			configs[0].Status.Status = redisv1.ClusterStatusReady
+			updateConfigStatus(ctx, &configs[0])
+			reconcileCluster(ctx, nn)
+
+			var cl redisv1.Redkey
+			Expect(k8sClient.Get(ctx, nn, &cl)).To(Succeed())
+			Expect(cl.Status.LastAppliedPrimaries).To(Equal(int32(0)))
+		})
+	})
+
+	Context("scale-up from zero is locked to the previous topology", func() {
+		It("is race-free: the lock holds immediately after scale-to-zero, without a reconcile", func() {
+			const name = "lock-race-free"
+			nn := types.NamespacedName{Name: name, Namespace: namespace}
+			bringToAppliedReady(newStorageCluster(name, 3, 0))
+			DeferCleanup(func() { deleteCluster(ctx, name, namespace) })
+
+			// Scale to zero (allowed).
+			Expect(updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 0 })).To(Succeed())
+
+			// Immediately try to scale up to a WRONG number, WITHOUT running any reconcile after the
+			// scale-to-zero. The value was recorded during the running phase, so the CEL rule must
+			// already reject this — proving there is no admission-vs-reconcile race.
+			err := updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 2 })
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(".status.lastAppliedPrimaries"))
+		})
+
+		It("rejects scaling up to fewer primaries", func() {
+			const name = "lock-fewer"
+			nn := types.NamespacedName{Name: name, Namespace: namespace}
+			bringToAppliedReady(newStorageCluster(name, 3, 0))
+			DeferCleanup(func() { deleteCluster(ctx, name, namespace) })
+
+			Expect(updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 0 })).To(Succeed())
+			err := updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 2 })
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("restore the same primaries"))
+		})
+
+		It("rejects scaling up to more primaries", func() {
+			const name = "lock-more"
+			nn := types.NamespacedName{Name: name, Namespace: namespace}
+			bringToAppliedReady(newStorageCluster(name, 3, 0))
+			DeferCleanup(func() { deleteCluster(ctx, name, namespace) })
+
+			Expect(updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 0 })).To(Succeed())
+			err := updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 5 })
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("restore the same primaries"))
+		})
+
+		It("accepts scaling up to the exact previous number of primaries", func() {
+			const name = "lock-exact"
+			nn := types.NamespacedName{Name: name, Namespace: namespace}
+			bringToAppliedReady(newStorageCluster(name, 3, 0))
+			DeferCleanup(func() { deleteCluster(ctx, name, namespace) })
+
+			Expect(updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 0 })).To(Succeed())
+			Expect(updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 3 })).To(Succeed())
+		})
+
+		It("reports the primaries rule (not replicas) when only primaries mismatch", func() {
+			const name = "lock-msg-noreplicas"
+			nn := types.NamespacedName{Name: name, Namespace: namespace}
+			bringToAppliedReady(newStorageCluster(name, 3, 0))
+			DeferCleanup(func() { deleteCluster(ctx, name, namespace) })
+
+			Expect(updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 0 })).To(Succeed())
+			err := updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 2 })
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(".status.lastAppliedPrimaries"))
+			Expect(err.Error()).NotTo(ContainSubstring("replicasPerPrimary"))
+		})
+	})
+
+	Context("scale-up from zero also locks replicasPerPrimary", func() {
+		It("rejects returning with a different number of replicas", func() {
+			const name = "lock-replicas-reject"
+			nn := types.NamespacedName{Name: name, Namespace: namespace}
+			bringToAppliedReady(newStorageCluster(name, 3, 1))
+			DeferCleanup(func() { deleteCluster(ctx, name, namespace) })
+
+			Expect(updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 0 })).To(Succeed())
+			err := updateSpec(nn, func(c *redisv1.Redkey) {
+				c.Spec.Primaries = 3
+				c.Spec.ReplicasPerPrimary = 2
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("restore the same replicasPerPrimary"))
+		})
+
+		It("accepts returning with the exact previous primaries and replicas", func() {
+			const name = "lock-replicas-accept"
+			nn := types.NamespacedName{Name: name, Namespace: namespace}
+			bringToAppliedReady(newStorageCluster(name, 3, 1))
+			DeferCleanup(func() { deleteCluster(ctx, name, namespace) })
+
+			Expect(updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 0 })).To(Succeed())
+			Expect(updateSpec(nn, func(c *redisv1.Redkey) {
+				c.Spec.Primaries = 3
+				c.Spec.ReplicasPerPrimary = 1
+			})).To(Succeed())
+		})
+	})
+
+	Context("clusters that are not restricted", func() {
+		It("allows any scale-up from zero for a fresh cluster created at zero (storage)", func() {
+			const name = "lock-fresh-zero"
+			nn := types.NamespacedName{Name: name, Namespace: namespace}
+			Expect(k8sClient.Create(ctx, newStorageCluster(name, 0, 0))).To(Succeed())
+			DeferCleanup(func() { deleteCluster(ctx, name, namespace) })
+			reconcileCluster(ctx, nn)
+
+			// Never ran, so nothing recorded; scaling up to any topology is allowed.
+			Expect(updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 5 })).To(Succeed())
+		})
+
+		It("allows any scale-up from zero for ephemeral clusters", func() {
+			const name = "lock-ephemeral-free"
+			nn := types.NamespacedName{Name: name, Namespace: namespace}
+			cluster := newTestCluster(name, namespace) // ephemeral, 3 primaries
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			DeferCleanup(func() { deleteCluster(ctx, name, namespace) })
+
+			Expect(updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 0 })).To(Succeed())
+			Expect(updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 2 })).To(Succeed())
+		})
+
+		It("allows free scaling while primaries stays > 0 for storage clusters", func() {
+			const name = "lock-free-nonzero"
+			nn := types.NamespacedName{Name: name, Namespace: namespace}
+			bringToAppliedReady(newStorageCluster(name, 3, 0))
+			DeferCleanup(func() { deleteCluster(ctx, name, namespace) })
+
+			// Never went through zero: scaling to any positive topology is allowed.
+			Expect(updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 5 })).To(Succeed())
+			Expect(updateSpec(nn, func(c *redisv1.Redkey) { c.Spec.Primaries = 2 })).To(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
Closes #60 

## Summary

Adds support for **hibernating storage (non-ephemeral) Redkeys**: scaling a persistent cluster to zero primaries tears down all compute (Redis pods, Robin, StatefulSet, Service, PDB, ConfigMap, RBAC) while keeping the data in its PVCs, and lets it be **woken up** by scaling back up. To guarantee a consistent restore, waking up is locked to the exact topology the cluster had before hibernating.

## Motivation

When a storage cluster is scaled to zero with `deletePVC: false`, the PersistentVolumes keep each node's `nodes.conf` (node IDs + slot ownership). Scaling back up to a **different** number of primaries/replicas remounts those volumes into a mismatched layout, producing an inconsistent cluster. This PR prevents that at admission time.

## Changes

### API / validation (`api/v1beta1/redkey_types.go`)
- New status fields `status.lastAppliedPrimaries` and `status.lastAppliedReplicasPerPrimary` (bounded `int32`) recording the last applied non-zero topology.
- Two **root-level** CEL validation rules on the `Redkey` type (root-level so they can read `self.status`) that reject scaling **up from zero** on storage clusters unless `primaries` and `replicasPerPrimary` match the recorded values. Free scaling while `primaries > 0`, ephemeral clusters, and fresh clusters created at `0` are unaffected.

### Controller (`internal/controller/redkey_config.go`)
- `aggregateStatus` now **continuously** records the last applied non-zero topology for non-ephemeral clusters (only when the active config is `Applied` at `primaries > 0`), never cleared. This makes the check **race-free**: the previous topology is always persisted before any scale-to-zero.

### Generated manifests
- Regenerated CRD (`config/crd/bases/...`) and synced the Helm chart CRD (`charts/redkey-operator/crds/redkeys-crd.yaml`).

### Documentation
- `docs/operator-guide/scaling.md` and `docs/redkey-cluster-status.md`: introduce the **hibernation** concept and document the scale-up-from-zero topology lock and the new status fields.
- `README.md`: reworded the presentation to be generic to both **cluster** and **standalone** Redkey modes.

### Tests
- **Integration** (`test/integration/scale_from_zero_lock_test.go`): CEL enforcement (accept/reject, exact-match on primaries and replicas), continuous-tracking, and race-free behavior via envtest.
- **E2E** (`test/e2e/scale_from_zero_lock_test.go`): full round-trip hibernate/wake-up on real clusters, plus rejection cases.
- **E2E** (`test/e2e/scaling_test.go`): scale-down PVC retention coverage for both `deletePVC: true` (removed ordinals' PVCs deleted) and `deletePVC: false` (retained).

## Notes

- `messageExpression` (dynamic error message) is intentionally **not** used: on this large CRD schema a root-level `messageExpression` reading `self.status` exceeds the API server's CEL cost budget. The static rejection message instead points users to `.status.lastAppliedPrimaries` / `.status.lastAppliedReplicasPerPrimary`.
- **Companion `redkeyrobin` changes are required** for the feature end-to-end (separate PR): a restore fast-path that skips cluster formation when nodes come back already covering all slots, and the StatefulSet PVC retention policy (`WhenScaled`) now following `deletePVC`.