### PR TITLE
Add control-plane operator metrics and fix dashboard scraping

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -144,7 +144,8 @@ This dashboard monitors the health and performance of the operator's controller-
 
 | Section | Panels |
 | ------- | ------ |
-| **Managed Redkey Fleet** | Total Redkeys, Ready, Configuring, Error (stats); phase and config-phase distribution; operation duration percentiles, operations by result, and operations in progress — from operator-exposed fleet metrics (`redkey_phase`, `redkey_config_phase`, `redkey_operation_*`), see [Managed Redkey Fleet metrics](#managed-redkey-fleet-metrics) |
+| **Managed Redkey Fleet** | Total Redkeys, Ready, Configuring, Error (stats); phase and config-phase distribution — from operator-exposed fleet metrics (`redkey_phase`, `redkey_config_phase`), see [Managed Redkey Fleet metrics](#managed-redkey-fleet-metrics) |
+| **Control-Plane Operations** | Operation duration percentiles, operations by result, operations in progress (`redkey_operation_*`); reconcile errors by stage (`redkey_reconcile_stage_errors_total`), config creations by reason (`redkey_config_creations_total`), configs deleted by cleanup (`redkey_cleanup_deleted_configs_total`), Robin deployment changes (`redkey_robin_deployment_changes_total`), and time-to-ready percentiles (`redkey_time_to_ready_seconds`), see [Managed Redkey Fleet metrics](#managed-redkey-fleet-metrics) |
 | **Overview** | Operator version (`redkey_operator_build_info`), uptime, leader election status, total reconciles, error rate %, active workers / max, reconcile panics |
 | **Reconciliation Performance** | Count by result (`increase`), rate by result (stacked), duration percentiles (p50/p95/p99), reconciliations by controller, average reconcile duration (`rate(sum)/rate(count)`), reconcile errors terminal vs non-terminal (`increase` by controller) |
 | **Work Queue** | Queue depth, adds rate, queue vs work duration (p95), retries rate, longest running processor, unfinished work |
@@ -285,6 +286,9 @@ Scope is deliberately narrow — only state the operator owns:
 - **Lifecycle phase** (`redkey_phase`, `redkey_config_phase`) — control-plane state.
 - **Operation timing** (`redkey_operation_duration_seconds`, `redkey_operation_total`) — how long
   scaling/upgrade/rebalance operations take and how they end, which nothing else measures.
+- **Control-plane activity** (`redkey_reconcile_stage_errors_total`, `redkey_config_creations_total`,
+  `redkey_cleanup_deleted_configs_total`, `redkey_robin_deployment_changes_total`,
+  `redkey_time_to_ready_seconds`) — where reconciles fail and the config/Robin churn they drive.
 
 Data-plane health (cluster healthy, slots covered, balance, memory, ...) is **not** mirrored here:
 it is owned and published by Robin (`redkey_cluster_*`, shown in the Redkey Cluster dashboard).
@@ -296,6 +300,11 @@ it is owned and published by Robin (`redkey_cluster_*`, shown in the Redkey Clus
 | `redkey_operation_duration_seconds` | histogram | duration from start until the cluster settles back to Ready/Error | `operation` |
 | `redkey_operation_total` | counter | completed operations | `operation`, `result` (`success`/`error`/`superseded`) |
 | `redkey_operation_in_progress` | gauge | the operation a Redkey is running **right now** (1 while in flight; removed on settle) | `namespace`, `name`, `operation` |
+| `redkey_reconcile_stage_errors_total` | counter | reconcile failures partitioned by the stage that returned the error | `stage` (`get_cluster`/`scale_to_zero`/`ensure_rbac`/`ensure_robin_deployment`/`list_configs`/`create_new_config`/`aggregate_status`/`cleanup_superseded_configs`) |
+| `redkey_config_creations_total` | counter | RedkeyConfig objects created by the operator | `reason` (`initial`/`generation_change`) |
+| `redkey_cleanup_deleted_configs_total` | counter | RedkeyConfig objects removed by cleanup once a newer config becomes Applied (not configs merely in the Superseded phase) | — |
+| `redkey_robin_deployment_changes_total` | counter | Robin Deployment create/patch operations | `action` (`create`/`patch`) |
+| `redkey_time_to_ready_seconds` | histogram | time from the active RedkeyConfig creation until the cluster reaches Ready (observed on every transition into Ready) | — |
 
 Because `redkey_phase`/`redkey_config_phase` carry the Redkey's own `namespace`/`name` labels, the
 operator's ServiceMonitor sets `honorLabels: true` so those are preserved instead of being
@@ -308,6 +317,10 @@ Example queries:
 - Upgrade duration p95: `histogram_quantile(0.95, sum by (le) (rate(redkey_operation_duration_seconds_bucket{operation="Upgrading"}[$__rate_interval])))`
 - Failed operations: `sum by (operation) (increase(redkey_operation_total{result="error"}[$__rate_interval]))`
 - Operations running right now: `redkey_operation_in_progress`
+- Reconcile failures by stage: `sum by (stage) (increase(redkey_reconcile_stage_errors_total[$__rate_interval]))`
+- Config creations by reason: `sum by (reason) (increase(redkey_config_creations_total[$__rate_interval]))`
+- Robin deployment drift (patch rate): `sum(increase(redkey_robin_deployment_changes_total{action="patch"}[$__rate_interval]))`
+- Time-to-ready p95: `histogram_quantile(0.95, sum by (le) (rate(redkey_time_to_ready_seconds_bucket[$__rate_interval])))`
 
 > `redkey_operation_*` (duration/total) are recorded only when an operation **completes**, so an
 > in-flight operation appears in `redkey_operation_in_progress` (live) but not yet in the

--- a/hack/observability/dashboards/redkey-operator.json
+++ b/hack/observability/dashboards/redkey-operator.json
@@ -1365,7 +1365,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (stage) (increase(redkey_reconcile_stage_errors_total[$__rate_interval]))",
+          "expr": "clamp_min(sum by (stage) (redkey_reconcile_stage_errors_total - (redkey_reconcile_stage_errors_total offset $__interval)), 0)",
+          "interval": "1m",
           "instant": false,
           "legendFormat": "{{stage}}",
           "range": true,
@@ -1458,7 +1459,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (reason) (increase(redkey_config_creations_total[$__rate_interval]))",
+          "expr": "clamp_min(sum by (reason) (redkey_config_creations_total - (redkey_config_creations_total offset $__interval)), 0)",
+          "interval": "1m",
           "instant": false,
           "legendFormat": "{{reason}}",
           "range": true,
@@ -1551,7 +1553,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(redkey_cleanup_deleted_configs_total[$__rate_interval]))",
+          "expr": "clamp_min(sum(redkey_cleanup_deleted_configs_total - (redkey_cleanup_deleted_configs_total offset $__interval)), 0)",
+          "interval": "1m",
           "instant": false,
           "legendFormat": "deleted",
           "range": true,
@@ -1644,7 +1647,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (action) (increase(redkey_robin_deployment_changes_total[$__rate_interval]))",
+          "expr": "clamp_min(sum by (action) (redkey_robin_deployment_changes_total - (redkey_robin_deployment_changes_total offset $__interval)), 0)",
+          "interval": "1m",
           "instant": false,
           "legendFormat": "{{action}}",
           "range": true,

--- a/hack/observability/dashboards/redkey-operator.json
+++ b/hack/observability/dashboards/redkey-operator.json
@@ -15,6 +15,502 @@
         "h": 1,
         "w": 24,
         "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 40,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "title": "Operator Version",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max by (version) (redkey_operator_build_info{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "instant": true,
+          "legendFormat": "{{version}}",
+          "range": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "STANDBY",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "LEADER",
+                  "color": "green"
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max(leader_election_master_status{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Leader Election",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(controller_runtime_reconcile_total{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Reconciles",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 9,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(controller_runtime_reconcile_errors_total{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) / clamp_min(sum(rate(controller_runtime_reconcile_total{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])), 0.000001)",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Error Rate",
+      "type": "stat",
+      "timeFrom": "5m"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(controller_runtime_active_workers{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "instant": true,
+          "legendFormat": "Active",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(controller_runtime_max_concurrent_reconciles{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "instant": true,
+          "legendFormat": "Max",
+          "range": false,
+          "refId": "B"
+        }
+      ],
+      "title": "Active Workers / Max",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 15,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(controller_runtime_reconcile_panics_total{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Panics",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 18,
+        "y": 1
+      },
+      "id": 49,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max(time() - process_start_time_seconds{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Uptime",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
         "y": 6
       },
       "id": 60,
@@ -472,6 +968,18 @@
       "type": "timeseries"
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 69,
+      "title": "Control-Plane Operations",
+      "type": "row"
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -530,9 +1038,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
+        "w": 12,
         "x": 0,
-        "y": 20
+        "y": 21
       },
       "id": 67,
       "options": {
@@ -647,9 +1155,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 20
+        "w": 12,
+        "x": 12,
+        "y": 21
       },
       "id": 68,
       "options": {
@@ -740,9 +1248,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 20
+        "w": 12,
+        "x": 0,
+        "y": 29
       },
       "id": 70,
       "options": {
@@ -775,114 +1283,54 @@
       "type": "timeseries"
     },
     {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 100,
-      "title": "Overview",
-      "type": "row"
-    },
-    {
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "Reconcile failures by the stage that returned the error (redkey_reconcile_stage_errors_total), increase per interval. Pinpoints which part of the reconcile loop is failing.",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": {
-                  "text": "STANDBY",
-                  "color": "red"
-                },
-                "1": {
-                  "text": "LEADER",
-                  "color": "green"
-                }
-              }
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
             }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 3,
-        "x": 3,
-        "y": 1
-      },
-      "id": 1,
-      "options": {
-        "colorMode": "background_solid",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "max(leader_election_master_status{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"})",
-          "instant": true,
-          "legendFormat": "",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Leader Election",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "red",
                 "value": null
               }
             ]
@@ -892,161 +1340,23 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
-        "w": 3,
-        "x": 6,
-        "y": 1
-      },
-      "id": 2,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(controller_runtime_reconcile_total{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"})",
-          "instant": true,
-          "legendFormat": "",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Total Reconciles",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 0.05
-              },
-              {
-                "color": "red",
-                "value": 0.1
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 3,
-        "x": 9,
-        "y": 1
-      },
-      "id": 3,
-      "options": {
-        "colorMode": "background_solid",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(controller_runtime_reconcile_errors_total{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) / clamp_min(sum(rate(controller_runtime_reconcile_total{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])), 0.000001)",
-          "instant": true,
-          "legendFormat": "",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Reconcile Error Rate",
-      "type": "stat",
-      "timeFrom": "5m"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 3,
+        "h": 8,
+        "w": 12,
         "x": 12,
-        "y": 1
+        "y": 29
       },
-      "id": 4,
+      "id": 71,
       "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
-        "textMode": "value_and_name",
-        "wideLayout": true
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
@@ -1055,37 +1365,58 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(controller_runtime_active_workers{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"})",
-          "instant": true,
-          "legendFormat": "Active",
-          "range": false,
+          "expr": "sum by (stage) (increase(redkey_reconcile_stage_errors_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "{{stage}}",
+          "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(controller_runtime_max_concurrent_reconciles{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"})",
-          "instant": true,
-          "legendFormat": "Max",
-          "range": false,
-          "refId": "B"
         }
       ],
-      "title": "Active Workers / Max",
-      "type": "stat"
+      "title": "Reconcile Errors by Stage",
+      "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "RedkeyConfig objects created by the operator by reason (redkey_config_creations_total): initial baseline vs spec/generation change. Increase per interval.",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
@@ -1094,10 +1425,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
               }
             ]
           },
@@ -1106,26 +1433,23 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
-        "w": 3,
-        "x": 15,
-        "y": 1
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 37
       },
-      "id": 5,
+      "id": 72,
       "options": {
-        "colorMode": "background_solid",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
-        "textMode": "auto",
-        "wideLayout": true
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
@@ -1134,25 +1458,151 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(controller_runtime_reconcile_panics_total{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"})",
-          "instant": true,
-          "legendFormat": "",
-          "range": false,
+          "expr": "sum by (reason) (increase(redkey_config_creations_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "{{reason}}",
+          "range": true,
           "refId": "A"
         }
       ],
-      "title": "Reconcile Panics",
-      "type": "stat"
+      "title": "Config Creations by Reason",
+      "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "RedkeyConfig objects removed by the cleanup step (redkey_cleanup_deleted_configs_total), increase per interval. Counts configs actually deleted once a newer config becomes Applied — not configs currently in the Superseded phase, which may still exist until then.",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 37
+      },
+      "id": 73,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(redkey_cleanup_deleted_configs_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "deleted",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Configs Deleted by Cleanup",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Robin Deployment create and patch operations performed by the operator (redkey_robin_deployment_changes_total) by action, increase per interval. Sustained patches indicate persistent drift.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
@@ -1164,31 +1614,28 @@
               }
             ]
           },
-          "unit": "dtdurations"
+          "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
-        "w": 3,
-        "x": 18,
-        "y": 1
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 45
       },
-      "id": 49,
+      "id": 74,
       "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
-        "textMode": "auto",
-        "wideLayout": true
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
@@ -1197,15 +1644,132 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "max(time() - process_start_time_seconds{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"})",
-          "instant": true,
-          "legendFormat": "",
-          "range": false,
+          "expr": "sum by (action) (increase(redkey_robin_deployment_changes_total[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "{{action}}",
+          "range": true,
           "refId": "A"
         }
       ],
-      "title": "Uptime",
-      "type": "stat"
+      "title": "Robin Deployment Changes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Time from the active RedkeyConfig creation until the cluster reaches Ready (redkey_time_to_ready_seconds), percentiles across the fleet. Observed on every transition into Ready — initial provisioning and after each scaling/upgrade/rebalance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 45
+      },
+      "id": 75,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(redkey_time_to_ready_seconds_bucket[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(redkey_time_to_ready_seconds_bucket[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(redkey_time_to_ready_seconds_bucket[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Time to Ready Percentiles",
+      "type": "timeseries"
     },
     {
       "collapsed": false,
@@ -1213,7 +1777,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 53
       },
       "id": 101,
       "title": "Reconciliation Performance",
@@ -1279,7 +1843,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 29
+        "y": 54
       },
       "id": 41,
       "options": {
@@ -1371,7 +1935,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 29
+        "y": 54
       },
       "id": 6,
       "options": {
@@ -1463,7 +2027,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 29
+        "y": 54
       },
       "id": 7,
       "options": {
@@ -1578,8 +2142,8 @@
       "gridPos": {
         "h": 8,
         "w": 8,
-        "x": 16,
-        "y": 37
+        "x": 0,
+        "y": 62
       },
       "id": 8,
       "options": {
@@ -1682,8 +2246,8 @@
       "gridPos": {
         "h": 8,
         "w": 8,
-        "x": 0,
-        "y": 37
+        "x": 8,
+        "y": 62
       },
       "id": 42,
       "options": {
@@ -1774,8 +2338,8 @@
       "gridPos": {
         "h": 8,
         "w": 8,
-        "x": 8,
-        "y": 37
+        "x": 16,
+        "y": 62
       },
       "id": 43,
       "options": {
@@ -1813,7 +2377,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 70
       },
       "id": 102,
       "title": "Work Queue",
@@ -1879,7 +2443,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 46
+        "y": 71
       },
       "id": 9,
       "options": {
@@ -1971,7 +2535,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 46
+        "y": 71
       },
       "id": 10,
       "options": {
@@ -2063,7 +2627,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 46
+        "y": 71
       },
       "id": 11,
       "options": {
@@ -2167,7 +2731,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 54
+        "y": 79
       },
       "id": 12,
       "options": {
@@ -2259,7 +2823,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 54
+        "y": 79
       },
       "id": 13,
       "options": {
@@ -2351,7 +2915,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 54
+        "y": 79
       },
       "id": 14,
       "options": {
@@ -2389,7 +2953,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 62
+        "y": 87
       },
       "id": 103,
       "title": "Kubernetes API Client",
@@ -2455,7 +3019,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 63
+        "y": 88
       },
       "id": 15,
       "options": {
@@ -2547,7 +3111,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 63
+        "y": 88
       },
       "id": 44,
       "options": {
@@ -2651,7 +3215,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 63
+        "y": 88
       },
       "id": 45,
       "options": {
@@ -2689,7 +3253,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 72
+        "y": 96
       },
       "id": 105,
       "title": "Process & Go Runtime",
@@ -2755,7 +3319,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 73
+        "y": 97
       },
       "id": 22,
       "options": {
@@ -2859,7 +3423,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 73
+        "y": 97
       },
       "id": 23,
       "options": {
@@ -2975,7 +3539,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 73
+        "y": 97
       },
       "id": 24,
       "options": {
@@ -3067,7 +3631,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 81
+        "y": 105
       },
       "id": 25,
       "options": {
@@ -3159,7 +3723,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 81
+        "y": 105
       },
       "id": 26,
       "options": {
@@ -3275,7 +3839,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 81
+        "y": 105
       },
       "id": 27,
       "options": {
@@ -3379,7 +3943,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 89
+        "y": 113
       },
       "id": 46,
       "options": {
@@ -3471,7 +4035,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 89
+        "y": 113
       },
       "id": 47,
       "options": {
@@ -3563,7 +4127,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 89
+        "y": 113
       },
       "id": 48,
       "options": {
@@ -3667,7 +4231,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 97
+        "y": 121
       },
       "id": 51,
       "options": {
@@ -3759,7 +4323,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 97
+        "y": 121
       },
       "id": 52,
       "options": {
@@ -3809,7 +4373,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 105
+        "y": 129
       },
       "id": 106,
       "title": "Kubernetes Container (cAdvisor + kube-state-metrics)",
@@ -3875,7 +4439,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 106
+        "y": 130
       },
       "id": 28,
       "options": {
@@ -3999,7 +4563,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 106
+        "y": 130
       },
       "id": 29,
       "options": {
@@ -4091,7 +4655,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 106
+        "y": 130
       },
       "id": 30,
       "options": {
@@ -4215,7 +4779,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 114
+        "y": 138
       },
       "id": 31,
       "options": {
@@ -4307,7 +4871,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 114
+        "y": 138
       },
       "id": 32,
       "options": {
@@ -4399,7 +4963,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 114
+        "y": 138
       },
       "id": 33,
       "options": {
@@ -4503,7 +5067,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 122
+        "y": 146
       },
       "id": 53,
       "options": {
@@ -4595,7 +5159,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 122
+        "y": 146
       },
       "id": 54,
       "options": {
@@ -4626,69 +5190,6 @@
       ],
       "title": "Pod Ready",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": null
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 3,
-        "x": 0,
-        "y": 1
-      },
-      "id": 40,
-      "options": {
-        "colorMode": "background_solid",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "name",
-        "wideLayout": true
-      },
-      "title": "Operator Version",
-      "type": "stat",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "max by (version) (redkey_operator_build_info{job=~\"$job\", namespace=~\"$namespace\", pod=~\"$pod\"})",
-          "instant": true,
-          "legendFormat": "{{version}}",
-          "range": false,
-          "refId": "A"
-        }
-      ]
     }
   ],
   "schemaVersion": 39,

--- a/hack/observability/servicemonitors.yaml
+++ b/hack/observability/servicemonitors.yaml
@@ -3,8 +3,8 @@
 
 # ServiceMonitor for Redkey Operator controller-manager.
 # Prometheus Operator uses this to discover and scrape the operator metrics endpoint.
-# The operator exposes metrics on HTTPS port 8443 via a Service created by kustomize
-# (config/default/metrics_service.yaml).
+# The operator exposes metrics on HTTP port 8080 via a Service created by kustomize
+# (config/default/metrics_service.yaml), matching --metrics-bind-address=:8080.
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -21,12 +21,9 @@ spec:
       control-plane: controller-manager
       app.kubernetes.io/name: redkey-operator
   endpoints:
-    - port: https
+    - port: http
       path: /metrics
-      scheme: https
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tlsConfig:
-        insecureSkipVerify: true
+      scheme: http
       interval: 15s
       # Keep metric-exposed labels (e.g. the Redkey's own `namespace`/`name` on the
       # redkey_phase / redkey_config_phase fleet metrics) instead of overwriting them with

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -61,6 +61,44 @@ var (
 		Name: "redkey_operation_in_progress",
 		Help: "The control-plane operation a managed Redkey is currently running (1 while in progress).",
 	}, []string{"namespace", "name", "operation"})
+
+	// redkeyReconcileStageErrors counts reconcile failures partitioned by the stage that returned
+	// the error, pinpointing which part of the reconcile loop is failing (RBAC, Robin deployment,
+	// config creation, status aggregation, ...) without the high cardinality of per-cluster labels.
+	redkeyReconcileStageErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "redkey_reconcile_stage_errors_total",
+		Help: "Total number of Redkey reconcile failures partitioned by the stage that returned the error.",
+	}, []string{"stage"})
+
+	// redkeyConfigCreations counts RedkeyConfig objects created by the operator, split by the
+	// reason a new config was needed: the first (baseline) config or a spec/generation change.
+	redkeyConfigCreations = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "redkey_config_creations_total",
+		Help: "Total number of RedkeyConfig objects created by the operator, by reason.",
+	}, []string{"reason"})
+
+	// redkeyCleanupDeletedConfigs counts superseded RedkeyConfig objects deleted by the cleanup
+	// step, giving visibility into config lineage churn.
+	redkeyCleanupDeletedConfigs = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "redkey_cleanup_deleted_configs_total",
+		Help: "Total number of superseded RedkeyConfig objects deleted by cleanup.",
+	})
+
+	// redkeyRobinDeploymentChanges counts create and patch operations the operator performs on the
+	// managed Robin Deployment, distinguishing initial creation from drift corrections.
+	redkeyRobinDeploymentChanges = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "redkey_robin_deployment_changes_total",
+		Help: "Total number of Robin Deployment create and patch operations, by action.",
+	}, []string{"action"})
+
+	// redkeyTimeToReady measures how long a cluster takes to reach Ready, timed from the active
+	// RedkeyConfig's creation. It is observed on every transition into Ready — both the initial
+	// provisioning and the return to Ready after a scaling, upgrade or rebalance operation.
+	redkeyTimeToReady = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "redkey_time_to_ready_seconds",
+		Help:    "Time from the active RedkeyConfig creation until the cluster reaches Ready.",
+		Buckets: []float64{5, 10, 20, 30, 60, 120, 300, 600, 900, 1800},
+	})
 )
 
 // redkeyPhaseValues and redkeyConfigPhaseValues enumerate every possible value so the state-set
@@ -80,7 +118,10 @@ var (
 )
 
 func init() {
-	crmetrics.Registry.MustRegister(redkeyPhase, redkeyConfigPhase, redkeyOperationDuration, redkeyOperationTotal, redkeyOperationInProgress)
+	crmetrics.Registry.MustRegister(
+		redkeyPhase, redkeyConfigPhase, redkeyOperationDuration, redkeyOperationTotal, redkeyOperationInProgress,
+		redkeyReconcileStageErrors, redkeyConfigCreations, redkeyCleanupDeletedConfigs, redkeyRobinDeploymentChanges, redkeyTimeToReady,
+	)
 }
 
 // recordRedkeyMetrics refreshes the fleet-state metrics for a single Redkey from its freshly
@@ -118,6 +159,13 @@ func recordRedkeyMetrics(cluster *redisv1.Redkey, activeConfig *redisv1.RedkeyCo
 		}
 		redkeyConfigPhase.WithLabelValues(ns, name, configPhase).Set(value)
 	}
+
+	// Time-to-ready: observe on every transition into the Ready phase, timed from the active
+	// config's creation. This covers the initial provisioning and every return to Ready after a
+	// scaling/upgrade/rebalance operation.
+	if readinessTracker.enteredReady(types.NamespacedName{Namespace: ns, Name: name}, cluster.Status.Phase) {
+		redkeyTimeToReady.Observe(time.Since(activeConfig.CreationTimestamp.Time).Seconds())
+	}
 }
 
 // deleteRedkeyMetrics removes every series belonging to a Redkey that no longer exists.
@@ -127,6 +175,7 @@ func deleteRedkeyMetrics(key types.NamespacedName) {
 	redkeyConfigPhase.DeletePartialMatch(crLabels)
 	redkeyOperationInProgress.DeletePartialMatch(crLabels)
 	operationTracker.forget(key)
+	readinessTracker.forget(key)
 }
 
 // operationTracker measures operation durations by watching the transitions of each Redkey's
@@ -179,5 +228,35 @@ func (t *opTracker) observe(key types.NamespacedName, status, phase string) {
 func (t *opTracker) forget(key types.NamespacedName) {
 	t.mu.Lock()
 	delete(t.active, key)
+	t.mu.Unlock()
+}
+
+// readinessTracker remembers each Redkey's last observed phase so time-to-ready is recorded only
+// on the transition INTO Ready, not on every steady-state reconcile while the cluster stays Ready.
+//
+// State is in-memory: after an operator restart the previous phase is unknown, so the first
+// post-restart observation of a Ready cluster counts as a transition and records one time-to-ready
+// sample against the current active config. This is acceptable noise for a histogram.
+var readinessTracker = &readyTracker{lastPhase: make(map[types.NamespacedName]string)}
+
+type readyTracker struct {
+	mu        sync.Mutex
+	lastPhase map[types.NamespacedName]string
+}
+
+// enteredReady reports whether the cluster just transitioned into the Ready phase, updating the
+// remembered phase as a side effect.
+func (t *readyTracker) enteredReady(key types.NamespacedName, phase string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	previous := t.lastPhase[key]
+	t.lastPhase[key] = phase
+	return phase == redisv1.PhaseReady && previous != redisv1.PhaseReady
+}
+
+func (t *readyTracker) forget(key types.NamespacedName) {
+	t.mu.Lock()
+	delete(t.lastPhase, key)
 	t.mu.Unlock()
 }

--- a/internal/controller/redkey_config.go
+++ b/internal/controller/redkey_config.go
@@ -122,6 +122,14 @@ func (r *RedkeyReconciler) createNewConfig(ctx context.Context, cluster *redisv1
 		return err
 	}
 
+	// Count only genuinely new configs (the AlreadyExists stale-cache path above is a no-op).
+	// The first config for a cluster is the baseline; every later one is a spec/generation change.
+	reason := "generation_change"
+	if highestSeq == nil {
+		reason = "initial"
+	}
+	redkeyConfigCreations.WithLabelValues(reason).Inc()
+
 	log.Info("Created new RedkeyConfig", "config", config.Name)
 	return nil
 }
@@ -333,9 +341,14 @@ func (r *RedkeyReconciler) cleanupSupersededConfigs(ctx context.Context, configs
 	}
 
 	for i := 0; i < lastApplied; i++ {
-		if err := r.Delete(ctx, &configs[i]); err != nil && !errors.IsNotFound(err) {
-			return configs[i:], err
+		if err := r.Delete(ctx, &configs[i]); err != nil {
+			if !errors.IsNotFound(err) {
+				return configs[i:], err
+			}
+			// Already gone (concurrent reconcile deleted it): don't double-count.
+			continue
 		}
+		redkeyCleanupDeletedConfigs.Inc()
 		log.Info("Deleted superseded RedkeyConfig", "config", configs[i].Name)
 	}
 

--- a/internal/controller/redkey_controller.go
+++ b/internal/controller/redkey_controller.go
@@ -73,6 +73,7 @@ func (r *RedkeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			log.Info("Redkey resource not found. Ignoring since object must be deleted.", "namespace", req.Namespace, "name", req.Name)
 			return ctrl.Result{}, nil
 		}
+		redkeyReconcileStageErrors.WithLabelValues("get_cluster").Inc()
 		return ctrl.Result{}, err
 	}
 
@@ -83,6 +84,8 @@ func (r *RedkeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		res, err := r.reconcileScaleToZero(ctx, &cluster)
 		if err == nil {
 			recordRedkeyMetrics(&cluster, nil)
+		} else {
+			redkeyReconcileStageErrors.WithLabelValues("scale_to_zero").Inc()
 		}
 		return res, err
 	}
@@ -90,18 +93,21 @@ func (r *RedkeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// Ensure RBAC resources exist for Robin
 	if err := r.ensureRBAC(ctx, &cluster); err != nil {
 		log.Error(err, "Failed to ensure RBAC resources")
+		redkeyReconcileStageErrors.WithLabelValues("ensure_rbac").Inc()
 		return ctrl.Result{}, err
 	}
 
 	// Ensure Robin Deployment exists
 	if err := r.ensureRobinDeployment(ctx, &cluster); err != nil {
 		log.Error(err, "Failed to ensure Robin Deployment")
+		redkeyReconcileStageErrors.WithLabelValues("ensure_robin_deployment").Inc()
 		return ctrl.Result{}, err
 	}
 
 	// List all RedkeyConfigs for this cluster
 	configs, err := r.listConfigs(ctx, &cluster)
 	if err != nil {
+		redkeyReconcileStageErrors.WithLabelValues("list_configs").Inc()
 		return ctrl.Result{}, err
 	}
 
@@ -114,12 +120,14 @@ func (r *RedkeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if len(configs) == 0 || needsNewConfig(&cluster, highestSeq) {
 		if err := r.createNewConfig(ctx, &cluster, highestSeq); err != nil {
 			log.Error(err, "Failed to create new RedkeyConfig")
+			redkeyReconcileStageErrors.WithLabelValues("create_new_config").Inc()
 			return ctrl.Result{}, err
 		}
 		log.Info("Created new RedkeyConfig", "cluster", cluster.Name, "generation", cluster.Generation)
 		// Re-fetch configs after creation
 		configs, err = r.listConfigs(ctx, &cluster)
 		if err != nil {
+			redkeyReconcileStageErrors.WithLabelValues("list_configs").Inc()
 			return ctrl.Result{}, err
 		}
 	}
@@ -129,12 +137,14 @@ func (r *RedkeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		configs, err = r.cleanupSupersededConfigs(ctx, configs)
 		if err != nil {
 			log.Error(err, "Failed to cleanup superseded configs")
+			redkeyReconcileStageErrors.WithLabelValues("cleanup_superseded_configs").Inc()
 			return ctrl.Result{}, err
 		}
 
 		// Aggregate status from highest-sequence config into Redkey status
 		if err := r.aggregateStatus(ctx, &cluster, configs); err != nil {
 			log.Error(err, "Failed to aggregate status")
+			redkeyReconcileStageErrors.WithLabelValues("aggregate_status").Inc()
 			return ctrl.Result{}, err
 		}
 	}

--- a/internal/controller/redkey_robin.go
+++ b/internal/controller/redkey_robin.go
@@ -266,7 +266,11 @@ func (r *RedkeyReconciler) ensureRobinDeployment(ctx context.Context, cluster *r
 	err := r.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, &existing)
 	if errors.IsNotFound(err) {
 		log.Info("Creating Robin Deployment", "deployment", desired.Name)
-		return r.Create(ctx, desired)
+		if err := r.Create(ctx, desired); err != nil {
+			return err
+		}
+		redkeyRobinDeploymentChanges.WithLabelValues("create").Inc()
+		return nil
 	}
 	if err != nil {
 		return err
@@ -283,7 +287,11 @@ func (r *RedkeyReconciler) ensureRobinDeployment(ctx context.Context, cluster *r
 		existing.Annotations = preserveManagedAnnotations(existing.Annotations, desired.Annotations)
 		existing.Spec.Replicas = desired.Spec.Replicas
 		existing.Spec.Template = desired.Spec.Template
-		return r.Patch(ctx, &existing, client.MergeFrom(base))
+		if err := r.Patch(ctx, &existing, client.MergeFrom(base)); err != nil {
+			return err
+		}
+		redkeyRobinDeploymentChanges.WithLabelValues("patch").Inc()
+		return nil
 	}
 
 	return nil


### PR DESCRIPTION
Closes #56 

## Add control-plane operator metrics, fix metrics scraping, and revamp the operator dashboard

### Summary
Introduces custom control-plane metrics for the Redkey operator, fixes a ServiceMonitor misconfiguration that left the operator dashboard empty, and reorganizes the operator Grafana dashboard for clarity.

### New metrics
Five custom metrics are registered on the controller-runtime Prometheus registry (served on the existing operator `/metrics` endpoint) and instrumented at their reconcile call sites:

| Metric | Type | Labels | Purpose |
| --- | --- | --- | --- |
| `redkey_reconcile_stage_errors_total` | counter | `stage` | Pinpoints which reconcile stage failed |
| `redkey_config_creations_total` | counter | `reason` | RedkeyConfig creations (`initial` vs `generation_change`) |
| `redkey_cleanup_deleted_configs_total` | counter | — | Configs removed by cleanup |
| `redkey_robin_deployment_changes_total` | counter | `action` | Robin Deployment `create`/`patch` operations |
| `redkey_time_to_ready_seconds` | histogram | — | Time from active config creation to Ready (observed on each transition into Ready) |

All labels use bounded enums to keep cardinality predictable (no per-cluster/name labels).

### Scraping fix
The operator ServiceMonitor scraped the metrics endpoint with `scheme/port: https`, but the operator serves plain HTTP on `:8080` (`--metrics-bind-address=:8080`, service port named `http`). Prometheus therefore generated **no target**, so every panel showed "No data". Switched the ServiceMonitor to `port/scheme: http` to match, and updated the stale comment referencing the 8443/HTTPS endpoint.

### Dashboard changes
- New **Control-Plane Operations** section (2 panels per row) grouping the existing operation panels plus the new metrics.
- **Overview** moved back to the top; all panel `gridPos` coordinates normalized to prevent section bleed-through (panels from one section rendering under another).
- Renamed **"Superseded Configs Deleted" → "Configs Deleted by Cleanup"** and clarified its description (it counts actual deletions, not configs merely in the `Superseded` phase).

### Docs
Updated `docs/observability.md` with the new metrics, example queries, and the revised dashboard layout.

### Testing
- `go build ./...`, `go vet ./...`, and `go test ./internal/controller/...` pass.
- Verified on a live cluster: operator target is `up`, and the new series (e.g. `redkey_config_creations_total`, `redkey_phase`) are ingested by Prometheus and rendered in Grafana.