### PR TITLE
Pin Redis image to `redis:8.10` in redkey-operator

### DIFF
--- a/charts/redkey/values.yaml
+++ b/charts/redkey/values.yaml
@@ -12,7 +12,7 @@ primaries: 3
 replicasPerPrimary: 0
 ephemeral: true
 purgeKeysOnRebalance: true
-image: redis:8-bookworm
+image: redis:8.10
 version: ""
 
 # Storage (only for non-ephemeral clusters)

--- a/config/manifests/bases/redkey-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/redkey-operator.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
             "primaries": 3,
             "ephemeral": true,
             "accessModes": ["ReadWriteOnce"],
-            "image": "redis:8-bookworm",
+            "image": "redis:8.10",
             "purgeKeysOnRebalance": true,
             "resources": {
               "limits": {

--- a/config/samples/auth/redkey_cluster.yaml
+++ b/config/samples/auth/redkey_cluster.yaml
@@ -18,7 +18,7 @@ spec:
   ephemeral: true
   accessModes:
     - ReadWriteOnce
-  image: redis:8-bookworm
+  image: redis:8.10
   purgeKeysOnRebalance: true
   auth:
     secret: redkey-auth-sample

--- a/config/samples/ephemeral/redkey_cluster.yaml
+++ b/config/samples/ephemeral/redkey_cluster.yaml
@@ -19,7 +19,7 @@ spec:
   ephemeral: true
   accessModes:
     - ReadWriteOnce
-  image: redis:8-bookworm
+  image: redis:8.10
   purgeKeysOnRebalance: true
   labels:
     inditex.dev/team: a-team

--- a/config/samples/replicas/redkey_cluster.yaml
+++ b/config/samples/replicas/redkey_cluster.yaml
@@ -19,7 +19,7 @@ spec:
   ephemeral: true
   accessModes:
     - ReadWriteOnce
-  image: redis:8-bookworm
+  image: redis:8.10
   purgeKeysOnRebalance: true
   labels:
     team: a-team

--- a/config/samples/standalone/redkey_standalone.yaml
+++ b/config/samples/standalone/redkey_standalone.yaml
@@ -24,7 +24,7 @@ spec:
   storageClassName: ""
   accessModes:
     - ReadWriteOnce
-  image: redis:8-bookworm
+  image: redis:8.10
   purgeKeysOnRebalance: false
   labels:
     team: a-team

--- a/config/samples/storage/redkey_cluster.yaml
+++ b/config/samples/storage/redkey_cluster.yaml
@@ -20,7 +20,7 @@ spec:
   storageClassName: ""
   accessModes:
     - ReadWriteOnce
-  image: redis:8-bookworm
+  image: redis:8.10
   purgeKeysOnRebalance: false
   labels:
     team: a-team

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,7 +94,7 @@ metadata:
 spec:
   primaries: 3
   replicasPerPrimary: 1
-  image: redis:8-bookworm
+  image: redis:8.10
   ephemeral: false
   storage: 1Gi
   storageClassName: standard

--- a/docs/chaos-testing.md
+++ b/docs/chaos-testing.md
@@ -169,7 +169,7 @@ make cleanup-test-chaos  # delete the Kind cluster
 | -------- | ------- | ----------- |
 | `IMAGE_OPERATOR` | `localhost:5005/redkey-operator:dev` | Operator image deployed (namespace-scoped) into each chaos namespace. |
 | `IMAGE_ROBIN` | `localhost:5005/redkey-robin:dev` | Robin image used by the cluster spec. |
-| `REDIS_IMAGE` | `redis:8-bookworm` | Redis image for cluster nodes. |
+| `REDIS_IMAGE` | `redis:8.10` | Redis image for cluster nodes. |
 | `K6_IMG` | `localhost:5005/redkey-k6:dev` | k6 load-generator image (built with the xk6-redis extension via `make k6-build`). |
 | `CHAOS_ITERATIONS` | `3` | Number of fault-injection iterations per scenario. More iterations increase coverage and run time. |
 | `CHAOS_SEED` | *(auto: Ginkgo random seed)* | Fixed RNG seed for reproducibility. The seed used is printed at suite start so a failing run can be replayed. |

--- a/docs/developer-guide/development-guide.md
+++ b/docs/developer-guide/development-guide.md
@@ -354,7 +354,7 @@ to `make test-e2e` or exported in your shell:
 | `E2E_HEALTH_TIMEOUT` | `600` | Maximum seconds to wait for health-related operations (remediation, node recovery, pod restart). Increase for tests that involve pod deletions or network disruptions. |
 | `IMAGE_OPERATOR` | `localhost:5005/redkey-operator:$(VERSION)` | Operator image loaded into Kind and deployed by the suite. |
 | `IMAGE_ROBIN` | `localhost:5005/redkey-robin:$(ROBIN_VERSION)` | Robin image used by the operator when creating Robin deployments. |
-| `REDIS_IMAGE` | `redis:8-bookworm` | Redis image for cluster nodes. |
+| `REDIS_IMAGE` | `redis:8.10` | Redis image for cluster nodes. |
 | `CERT_MANAGER_INSTALL_SKIP` | *(unset)* | Set to `true` to skip CertManager installation (if already present). |
 | `OPERATOR_DEPLOY_SKIP` | *(unset)* | Set to `true` to skip operator deployment (if already deployed manually). |
 | `LABEL` | *(unset)* | Ginkgo label filter to run a subset of specs (e.g. `creation`, `helm`, `health`). |

--- a/test/chaos/framework/env.go
+++ b/test/chaos/framework/env.go
@@ -48,7 +48,7 @@ const (
 	// defaultRobinImage is the Robin image used when IMAGE_ROBIN is unset.
 	defaultRobinImage = "localhost:5005/redkey-robin:dev"
 	// defaultRedisImage is the Redis image used when REDIS_IMAGE is unset.
-	defaultRedisImage = "redis:8-bookworm"
+	defaultRedisImage = "redis:8.10"
 	// defaultK6Image is the k6 load-generator image used when K6_IMG is unset.
 	defaultK6Image = "localhost:5005/redkey-k6:dev"
 	// defaultK6VUs is the number of k6 virtual users used when CHAOS_K6_VUS is unset.

--- a/test/e2e/framework/cluster.go
+++ b/test/e2e/framework/cluster.go
@@ -20,7 +20,7 @@ import (
 
 // Default images and constants.
 const (
-	defaultRedisImage = "redis:8-bookworm"
+	defaultRedisImage = "redis:8.10"
 	defaultConfig     = `maxmemory 90mb
 maxmemory-policy allkeys-lru
 protected-mode no

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -25,7 +25,7 @@ import (
 
 // getRedisUpgradeImage returns the target image for upgrade tests.
 // Use REDIS_IMAGE_UPGRADE env var to set a custom target, otherwise defaults to "redis:8-alpine"
-// (a compatible but different image tag from the default "redis:8-bookworm").
+// (a compatible but different image tag from the default "redis:8.10").
 func getRedisUpgradeImage() string {
 	if img := os.Getenv("REDIS_IMAGE_UPGRADE"); img != "" {
 		return img


### PR DESCRIPTION
## What
Replace the floating `redis:8-bookworm` tag with the pinned minor tag `redis:8.10` as the default Redis image across the `redkey-operator` (chart, samples, docs and test frameworks), and regenerate the OLM bundle so the `alm-examples` reflect the new value.

## Why
`redis:8-bookworm` floats to the latest `8.x`, which can silently pull in a new minor version and cause unexpected behavior changes or CI/e2e flakiness. Pinning to the `8.10` minor keeps deployments deterministic in behavior while still receiving patch-level bugfix/security updates automatically.

## Changes
- `charts/redkey/values.yaml`: default `image` → `redis:8.10`.
- `config/samples/*` (auth, ephemeral, replicas, standalone, storage): sample images → `redis:8.10`.
- `docs/architecture.md`, `docs/chaos-testing.md`, `docs/developer-guide/development-guide.md`: `REDIS_IMAGE` default and example updated.
- `test/chaos/framework/env.go`, `test/e2e/framework/cluster.go`: `defaultRedisImage` → `redis:8.10`.
- `test/e2e/upgrade_test.go`: comment updated (upgrade target `redis:8-alpine` kept intentionally, as it must differ from the default to trigger an upgrade).
- `config/manifests/bases/...` and `bundle/manifests/...` CSVs: `alm-examples` regenerated via `make bundle`.

## Out of scope
- `redkey-robin` default (`redis:8`) is left unchanged.
- Illustrative `redis:7.x` / `redis:8` examples in upgrade/override/metrics docs and integration test fixtures are unchanged.

## Validation
- Confirmed `redis:8.10` exists in the registry.
- `grep redis:8-bookworm` across `redkey-operator/` → no matches.
- `make bundle` completed and `operator-sdk bundle validate ./bundle` passed.
- `go build` + `go vet` of the affected test packages pass.